### PR TITLE
Add option to remove used qualities

### DIFF
--- a/QualityRecipesCalculator/Entities/RecipeCombination.cs
+++ b/QualityRecipesCalculator/Entities/RecipeCombination.cs
@@ -42,9 +42,15 @@ namespace TehGM.PoE.QualityRecipesCalculator
         public static IDictionary<Item, int> ExtractItemQualities(IEnumerable<Item> items)
         {
             Dictionary<Item, int> results = new Dictionary<Item, int>(items.Count());
+            int debugCount = 0;
 
             foreach (Item i in items)
             {
+                debugCount++;
+                if (debugCount % 1000 == 0)
+                {
+                    Serilog.Log.Debug("{xThousand}k qualities extracted", debugCount / 1000);
+                }
                 if (!i.TryGetProperty("Quality", out ItemProperty prop))
                     throw new ArgumentException($"Item {i} has no quality property", nameof(items));
                 results.Add(i, int.Parse(prop.Values.First().TrimStart('+').TrimEnd('%')));

--- a/QualityRecipesCalculator/Entities/RecipeCombination.cs
+++ b/QualityRecipesCalculator/Entities/RecipeCombination.cs
@@ -39,7 +39,7 @@ namespace TehGM.PoE.QualityRecipesCalculator
         public static RecipeCombination Calculate(IEnumerable<Item> items, int targetQuality = 40)
             => Calculate(ExtractItemQualities(items), targetQuality);
 
-        public static IReadOnlyDictionary<Item, int> ExtractItemQualities(IEnumerable<Item> items)
+        public static IDictionary<Item, int> ExtractItemQualities(IEnumerable<Item> items)
         {
             Dictionary<Item, int> results = new Dictionary<Item, int>(items.Count());
 

--- a/QualityRecipesCalculator/Options.cs
+++ b/QualityRecipesCalculator/Options.cs
@@ -21,6 +21,8 @@ namespace TehGM.PoE.QualityRecipesCalculator
         public bool ShowItemNames { get; set; }
         [Option("large", Required = false, HelpText = "Amount of items that will be considered a large batch and produce warning", Default = (uint)20)]
         public uint LargeBatchSize { get; set; }
+        [Option("remove-used", Required = false, HelpText = "Qualities used in prior combinations are not re-used in future combinations", Default = false)]
+        public bool RemoveUsed { get; set; }
 
         [Option("debug", Required = false, HelpText = "Enables debug output", Default = false)]
         public bool Debug { get; set; }

--- a/QualityRecipesCalculator/RecipesCalculator.cs
+++ b/QualityRecipesCalculator/RecipesCalculator.cs
@@ -70,21 +70,35 @@ namespace TehGM.PoE.QualityRecipesCalculator
             Log.Verbose("Generating permutations");
             IEnumerable<IEnumerable<KeyValuePair<Item, int>>> permutations = Permutator.GetCombinations(qualities, requirements.MaxItems);
 
-            // track already done just to reduce spam in output
+            Log.Verbose("Creating hashset to keep track of valid combinations");
+            // track already done to reduce spam in output
             HashSet<RecipeCombination> alreadyDone = new HashSet<RecipeCombination>();
+            Log.Verbose("Created hashset!");
             // only output tab name the first time
             bool tabNameShown = false;
             // skip showing invalid if capacity is exceeded
-            bool exceedsCapacity = permutations.LongCount() > int.MaxValue / 2;
+            //bool exceedsCapacity = permutations.LongCount() > int.MaxValue / 2;
+            bool exceedsCapacity = true;
+            Log.Verbose("Checking if exceeds capacity");
             if (exceedsCapacity && _options.ShowInvalid)
+            {
+                Log.Verbose("Exceeds capacity!");
                 Log.Warning("Possible combinations count exceed capacity - logging of invalid combinations will be disabled");
+            }
             Log.Verbose("Permutations generated in {Time} ms", this._stopwatch.ElapsedMilliseconds);
 
             // calculate total quality of each combination
             Log.Verbose("Calculating combinations");
+
+            Log.Verbose("Total of {PermutationCount} permutations; {IntMax} is IntMax", permutations.LongCount(), int.MaxValue);
             int lastIter = permutations.Count();
             for (int iter = 0; iter < lastIter; iter++)
             {
+                /*
+                if ((iter + 1) % 1000 == 0)
+                    Log.Verbose("Calculated {xThousand}k combinations..", iter / 1000);
+                */
+                Log.Verbose($"Combination {iter}");
                 IEnumerable<KeyValuePair<Item, int>> sequence = permutations.ElementAt(iter);
                 RecipeCombination combination = RecipeCombination.Calculate(sequence, requirements.TargetQuality);
 
@@ -153,6 +167,7 @@ namespace TehGM.PoE.QualityRecipesCalculator
             if (!_options.OnlyExact)
                 message += ", consider running with --only-exact flag - might improve performance by about 30%";
             Log.Warning(message, itemsCount, tabName);
+            return;
         }
     }
 }


### PR DESCRIPTION
* Add option `--remove-used`
  * Remove qualities used in prior combinations before calculating new combinations
  * Allow duplicate valid combinations to be listed, as removing duplicates would leave the user with leftover combinations